### PR TITLE
Fix checkpoints position within track bounds

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -20,16 +20,16 @@ const leaderboardListEl = document.getElementById('leaderboardList');
 const track = {
     width: 60,
     checkpoints: [
-        { x: 100, y: 300, passed: false },
+        { x: 150, y: 300, passed: false },
         { x: 200, y: 200, passed: false },
         { x: 400, y: 150, passed: false },
         { x: 600, y: 200, passed: false },
-        { x: 700, y: 300, passed: false },
+        { x: 650, y: 300, passed: false },
         { x: 600, y: 400, passed: false },
         { x: 400, y: 450, passed: false },
         { x: 200, y: 400, passed: false }
     ],
-    startX: 100,
+    startX: 150,
     startY: 300,
     startAngle: 0
 };


### PR DESCRIPTION
## Summary
- adjust racetrack checkpoints to sit inside the circular track
- update start position so cars spawn on the track

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: No files matching the pattern "tests/**/*.js" were found)*

------
https://chatgpt.com/codex/tasks/task_e_68740e2100fc8323b3881d5faf02e21d