### PR TITLE
Allow skipping to next generation mid-race

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -649,7 +649,7 @@ function nextGeneration() {
     
     updateUI();
     isRunning = true;
-    nextGenBtn.disabled = true;
+    nextGenBtn.disabled = false;
     updateSimulation();
 }
 
@@ -668,11 +668,16 @@ startBtn.addEventListener('click', () => {
     initSimulation();
     isRunning = true;
     startBtn.disabled = true;
+    nextGenBtn.disabled = false;
     cancelAnimationFrame(animationId);
     updateSimulation();
 });
 
 nextGenBtn.addEventListener('click', () => {
+    if (isRunning) {
+        isRunning = false;
+        cancelAnimationFrame(animationId);
+    }
     nextGeneration();
 });
 


### PR DESCRIPTION
## Summary
- enable 'Next Generation' button while a simulation is running
- allow manually skipping to the next generation

## Testing
- `npm run lint` *(fails: No files matching the pattern "tests/**/*.js" were found)*
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6874119752848323862a8312c512a6e2