### PR TITLE
Add basic server tests

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -224,13 +224,13 @@ class Car {
         this.sensors = [];
     }
     
-    update(track) {
+    update() {
         if (this.crashed || this.completed) return;
         
         this.time += 0.1;
         
         // Get sensor readings
-        this.sensors = this.getSensorReadings(track);
+        this.sensors = this.getSensorReadings();
         
         // Use neural network to decide actions
         const inputs = [
@@ -278,7 +278,7 @@ class Car {
         this.fitness = this.distance + (8 - nextCheckpointIndex) * 1000 - distanceToNext;
         
         // Check for checkpoint passing
-        this.checkpoints.forEach((checkpoint, index) => {
+        this.checkpoints.forEach(checkpoint => {
             if (!checkpoint.passed) {
                 const dx = checkpoint.x - this.x;
                 const dy = checkpoint.y - this.y;
@@ -308,29 +308,29 @@ class Car {
         }
     }
     
-    getSensorReadings(track) {
+    getSensorReadings() {
         const sensorLength = 100;
         const sensors = [];
         
         // Forward sensor
-        sensors.push(this.castRay(0, sensorLength, track));
+        sensors.push(this.castRay(0, sensorLength));
         
         // Left sensor
-        sensors.push(this.castRay(-Math.PI/2, sensorLength, track));
+        sensors.push(this.castRay(-Math.PI/2, sensorLength));
         
         // Right sensor
-        sensors.push(this.castRay(Math.PI/2, sensorLength, track));
+        sensors.push(this.castRay(Math.PI/2, sensorLength));
         
         // Forward-left sensor
-        sensors.push(this.castRay(-Math.PI/4, sensorLength, track));
+        sensors.push(this.castRay(-Math.PI/4, sensorLength));
         
         // Forward-right sensor
-        sensors.push(this.castRay(Math.PI/4, sensorLength, track));
+        sensors.push(this.castRay(Math.PI/4, sensorLength));
         
         return sensors;
     }
     
-    castRay(angleOffset, length, track) {
+    castRay(angleOffset, length) {
         const rayAngle = this.angle + angleOffset;
         let distance = 0;
         const stepSize = 2;
@@ -511,7 +511,7 @@ function updateSimulation() {
         
         cars.forEach(car => {
             if (!car.crashed && !car.completed) {
-                car.update(track);
+                car.update();
                 allDone = false;
             }
         });
@@ -525,9 +525,7 @@ function updateSimulation() {
     
     // Update progress
     let totalProgress = 0;
-    let completedCount = 0;
     cars.forEach(car => {
-        if (car.completed) completedCount++;
         totalProgress += car.checkpoints.filter(c => c.passed).length;
     });
     

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 const server = http.createServer((req, res) => {
   let filePath = '.' + req.url;
@@ -40,6 +40,10 @@ const server = http.createServer((req, res) => {
   });
 });
 
-server.listen(PORT, () => {
-  console.log(`Server running at http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Server running at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = server;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,35 @@
+const http = require('http');
+const server = require('../server');
+
+let port;
+let listener;
+
+beforeAll(done => {
+  listener = server.listen(0, () => {
+    port = listener.address().port;
+    done();
+  });
+});
+
+afterAll(done => {
+  listener.close(done);
+});
+
+test('serves index.html at root path', done => {
+  http.get({ port, path: '/' }, res => {
+    expect(res.statusCode).toBe(200);
+    let data = '';
+    res.on('data', chunk => (data += chunk));
+    res.on('end', () => {
+      expect(data).toContain('AI Racing Simulator');
+      done();
+    });
+  });
+});
+
+test('returns 404 for missing file', done => {
+  http.get({ port, path: '/nonexistent' }, res => {
+    expect(res.statusCode).toBe(404);
+    done();
+  });
+});


### PR DESCRIPTION
## Summary
- adjust server.js so it only starts when executed directly
- export the server for testing
- fix unused variables in game.js discovered by lint
- add Jest tests for the HTTP server

## Testing
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687414216fec83238e9296c65d5dbadd