### PR TITLE
Reverse checkpoint pulsation

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -565,7 +565,10 @@ function drawTrack() {
     // Draw checkpoints with animation
     for (let i = 0; i < checkpoints.length; i++) {
         const checkpoint = checkpoints[i];
-        const pulse = Math.sin(Date.now() * 0.005 + i) * 0.2 + 0.8;
+        // Reverse the pulsating order by offsetting the phase with the
+        // reversed checkpoint index.
+        const reverseIndex = checkpoints.length - 1 - i;
+        const pulse = Math.sin(Date.now() * 0.005 + reverseIndex) * 0.2 + 0.8;
         
         // Outer glow
         ctx.shadowColor = '#ffaa00';


### PR DESCRIPTION
## Summary
- reverse checkpoint pulse order so glow goes from last to first

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875405f1b888323bc008b82094d86dc