### PR TITLE
Add themed title screen overlay

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -262,3 +262,39 @@ button:active {
 .generating {
     animation: pulse 1s ease-in-out infinite;
 }
+
+#titleScreen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    padding: 60px 20px;
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.6) 100%);
+    pointer-events: none;
+    z-index: 10;
+    text-align: center;
+}
+
+#titleScreen h1 {
+    font-size: 48px;
+    color: #00ff88;
+    margin: 0;
+    text-shadow: 0 0 10px rgba(0, 255, 136, 0.7);
+}
+
+#titleScreen h2 {
+    font-size: 24px;
+    color: #00ffff;
+    margin: auto 0;
+}
+
+#titleScreen p {
+    font-size: 16px;
+    color: #00ff88;
+    margin-bottom: 0;
+}

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -18,6 +18,7 @@ const bestFitnessEl = document.getElementById('bestFitness');
 const carsRunningEl = document.getElementById('carsRunning');
 const leaderboardList = document.getElementById('leaderboardList');
 const trackSelect = document.getElementById('trackSelect');
+const titleScreen = document.getElementById('titleScreen');
 
 // Game parameters
 let populationSize = 50;
@@ -829,6 +830,7 @@ nextGenBtn.addEventListener('click', () => {
 
 startStopBtn.addEventListener('click', async () => {
     if (!started) {
+        if (titleScreen) titleScreen.style.display = 'none';
         await start();
         startStopBtn.textContent = 'Stop';
         started = true;

--- a/index.html
+++ b/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
+    <div id="titleScreen">
+        <h1>Zoomies!</h1>
+        <h2>Train your racecar driver</h2>
+        <p>Pick a track and press start</p>
+    </div>
     <div id="gameContainer">
         <canvas id="canvas" width="800" height="800"></canvas>
         <div id="controls">


### PR DESCRIPTION
## Summary
- create introductory title screen overlay
- style the overlay to match the theme
- hide the title screen on first start

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6875fd6fc32c8323be7e78cc0fc6879f