### PR TITLE
Add mousedown throttle in track editor

### DIFF
--- a/assets/js/trackEditor.js
+++ b/assets/js/trackEditor.js
@@ -6,6 +6,7 @@ if (editorCanvas) {
   let mode = 'outer';
   let currentPoint = null;
   let drawing = true;
+  let lastDrawTime = 0;
   let dragging = null;
   let checkpointsEditor = [];
   let addCp = false;
@@ -137,6 +138,9 @@ if (editorCanvas) {
     }
 
     if (drawing) {
+      const now = Date.now();
+      if (now - lastDrawTime < 200) return;
+      lastDrawTime = now;
       if (!currentPoint) {
         currentPoint = { x: pos.x, y: pos.y };
       } else {


### PR DESCRIPTION
## Summary
- avoid dropping duplicate points by throttling drawing clicks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68761e582f5883239f0db1a9f9842593