### PR TITLE
Add load functionality to track editor

### DIFF
--- a/assets/js/trackEditor.js
+++ b/assets/js/trackEditor.js
@@ -199,7 +199,7 @@ if (editorCanvas) {
   });
 
   if (loadBtn) {
-    loadBtn.addEventListener('click', () => {
+    loadBtn.addEventListener('mousedown', () => {
       if (!dataArea) return;
       try {
         const data = JSON.parse(dataArea.value);
@@ -210,7 +210,7 @@ if (editorCanvas) {
         currentPoint = null;
         mode = 'outer';
         toggleBtn.textContent = 'Editing outer';
-        updateData();
+        draw();
       } catch {
         alert('Invalid track data');
       }

--- a/assets/js/trackEditor.js
+++ b/assets/js/trackEditor.js
@@ -115,7 +115,6 @@ if (editorCanvas) {
       ctx.fillStyle = '#ff8800';
       ctx.fill();
     });
-    updateData();
     requestAnimationFrame(draw);
   }
   updateData();
@@ -174,6 +173,7 @@ if (editorCanvas) {
 
   window.addEventListener('mouseup', () => {
     dragging = null;
+    updateData();
   });
 
   editorCanvas.addEventListener('dblclick', () => {
@@ -210,6 +210,7 @@ if (editorCanvas) {
         currentPoint = null;
         mode = 'outer';
         toggleBtn.textContent = 'Editing outer';
+        updateData();
       } catch {
         alert('Invalid track data');
       }

--- a/assets/js/trackEditor.js
+++ b/assets/js/trackEditor.js
@@ -17,12 +17,20 @@ if (editorCanvas) {
   const removeBtn = document.getElementById('removeCheckpointBtn');
   const dataArea = document.getElementById('trackData');
   const copyBtn = document.getElementById('copyTrackBtn');
+  const loadBtn = document.getElementById('loadTrackBtn');
 
   const formatSeg = seg => ({
     start: [seg.start.x, seg.start.y],
     cp1: [seg.cp1.x, seg.cp1.y],
     cp2: [seg.cp2.x, seg.cp2.y],
     end: [seg.end.x, seg.end.y]
+  });
+
+  const parseSeg = seg => ({
+    start: { x: seg.start[0], y: seg.start[1] },
+    cp1: { x: seg.cp1[0], y: seg.cp1[1] },
+    cp2: { x: seg.cp2[0], y: seg.cp2[1] },
+    end: { x: seg.end[0], y: seg.end[1] }
   });
 
   const rectFromSegs = segs => {
@@ -189,4 +197,22 @@ if (editorCanvas) {
     removeCp = !removeCp;
     addCp = false;
   });
+
+  if (loadBtn) {
+    loadBtn.addEventListener('click', () => {
+      if (!dataArea) return;
+      try {
+        const data = JSON.parse(dataArea.value);
+        shapes.outer = data.curves.outer.map(parseSeg);
+        shapes.inner = data.curves.inner.map(parseSeg);
+        checkpointsEditor = data.checkpoints.map(c => ({ x: c.x, y: c.y }));
+        drawing = false;
+        currentPoint = null;
+        mode = 'outer';
+        toggleBtn.textContent = 'Editing outer';
+      } catch {
+        alert('Invalid track data');
+      }
+    });
+  }
 }

--- a/index.html
+++ b/index.html
@@ -70,12 +70,13 @@
         </div>
         <div id="editorContainer">
             <canvas id="trackEditor" width="800" height="800"></canvas>
-            <textarea id="trackData" rows="10" cols="80" readonly></textarea>
+            <textarea id="trackData" rows="10" cols="80"></textarea>
             <div id="editorControls">
                 <button id="toggleShapeBtn">Editing outer</button>
                 <button id="addCheckpointBtn">Add Checkpoint</button>
                 <button id="removeCheckpointBtn">Remove Checkpoint</button>
                 <button id="copyTrackBtn">Copy</button>
+                <button id="loadTrackBtn">Load</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- allow editing track JSON
- add button to load JSON back into the editor
- support parsing segments and disable drawing when loading

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68764ff08b0883239f24364258607dbb