### PR TITLE
Add track editor option

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -580,8 +580,20 @@ function sigmoid(x) {
 
 // Initialize the track
 async function loadTrack(name = 'square') {
-    const res = await fetch(`assets/tracks/${name}.json`);
-    const data = await res.json();
+    let data;
+    if (name === 'editor') {
+        const textarea = document.getElementById('trackData');
+        try {
+            data = textarea ? JSON.parse(textarea.value) : null;
+        } catch (e) {
+            console.error('Invalid track data');
+            data = null;
+        }
+        if (!data) return;
+    } else {
+        const res = await fetch(`assets/tracks/${name}.json`);
+        data = await res.json();
+    }
     track = [];
     checkpoints = data.checkpoints;
     outerBounds = data.outerRect;

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
                     <option value="ellipse">Ellipse</option>
                     <option value="square">Square</option>
                     <option value="complex">Complex</option>
+                    <option value="editor">Track editor</option>
                 </select>
             </div>
             <div class="control-group">


### PR DESCRIPTION
## Summary
- add Track editor option in the track dropdown
- allow game.js to load track data from the editor textarea

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876504de8ac8323ba764ac036df7c73