### PR TITLE
Add reset button to restart simulation

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -35,6 +35,15 @@ body {
     gap: 15px;
 }
 
+#buttonRow {
+    display: flex;
+    gap: 20px;
+}
+
+#buttonRow button {
+    flex: 1;
+}
+
 .control-group {
     display: flex;
     justify-content: space-between;

--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -19,6 +19,7 @@ const mutationSlider = document.getElementById('mutationSlider');
 const mutationValue = document.getElementById('mutationValue');
 const nextGenBtn = document.getElementById('nextGenBtn');
 const startStopBtn = document.getElementById('startStopBtn');
+const resetBtn = document.getElementById('resetBtn');
 const generationEl = document.getElementById('generation');
 const bestFitnessEl = document.getElementById('bestFitness');
 const catsRunningEl = document.getElementById('catsRunning');
@@ -814,8 +815,28 @@ async function start() {
     await loadTrack(trackSelect.value);
     initCats();
     isRunning = true;
-    bestFitnessEl.textContent = `#${bestCatId} ${Math.round(bestFitnessOverall)}`;
+    if (bestCatId) {
+        bestFitnessEl.textContent = `#${bestCatId} ${Math.round(bestFitnessOverall)}`;
+    } else {
+        bestFitnessEl.textContent = Math.round(bestFitnessOverall);
+    }
     update();
+}
+
+async function resetSimulation() {
+    isRunning = false;
+    bestCats = [];
+    bestOverallCats = [];
+    bestFitnessOverall = 0;
+    bestCatId = null;
+    generation = 1;
+    nextCatId = 1;
+    generationEl.textContent = generation;
+    bestFitnessEl.textContent = 0;
+    if (titleScreen) titleScreen.style.display = 'none';
+    started = true;
+    await start();
+    startStopBtn.textContent = 'Stop';
 }
 
 // Event listeners
@@ -847,6 +868,12 @@ mutationSlider.addEventListener('input', () => {
 nextGenBtn.addEventListener('click', () => {
     nextGeneration();
 });
+
+if (resetBtn) {
+    resetBtn.addEventListener('click', async () => {
+        await resetSimulation();
+    });
+}
 
 startStopBtn.addEventListener('click', async () => {
     if (!started) {

--- a/index.html
+++ b/index.html
@@ -15,7 +15,11 @@
         </div>
         <canvas id="canvas" width="800" height="800"></canvas>
         <div id="controls">
-            <button id="startStopBtn">Start</button>
+            <div id="buttonRow">
+                <button id="startStopBtn">Start</button>
+                <button id="nextGenBtn">Next Generation</button>
+                <button id="resetBtn">Reset</button>
+            </div>
             <div class="control-group">
                 <label for="trackSelect">Track</label>
                 <select id="trackSelect">
@@ -50,7 +54,6 @@
                 <input type="range" id="mutationSlider" min="0.01" max="0.5" value="0.1" step="0.01">
                 <span id="mutationValue" class="value-display">0.1</span>
             </div>
-            <button id="nextGenBtn">Next Generation</button>
         </div>
         <div id="stats">
             <div class="stat-box">


### PR DESCRIPTION
## Summary
- add reset button to restart the simulation and clear best cat
- layout controls in a new flex row
- style the button row
- guard reset event handler for tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876869ea2808323b6c3735091bdbd40