### PR TITLE
Fix curve endpoint dragging

### DIFF
--- a/assets/js/trackEditor.js
+++ b/assets/js/trackEditor.js
@@ -168,6 +168,16 @@ if (editorCanvas) {
       const pos = getPos(e);
       dragging.seg[dragging.type].x = pos.x;
       dragging.seg[dragging.type].y = pos.y;
+
+      if (dragging.type === 'end') {
+        const segs = shapes[mode];
+        const idx = segs.indexOf(dragging.seg);
+        if (idx !== -1 && segs.length > 0) {
+          const nextSeg = segs[(idx + 1) % segs.length];
+          nextSeg.start.x = pos.x;
+          nextSeg.start.y = pos.y;
+        }
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure curve endpoints stay connected when dragging

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687689d148188323ad32aa23d18e9583