### PR TITLE
Add reverse speed penalty

### DIFF
--- a/assets/js/game.js
+++ b/assets/js/game.js
@@ -177,7 +177,8 @@ class Cat {
             this.speed -= this.friction;
             if (this.speed < 0) this.speed = 0;
         } else if (this.speed < 0) {
-            this.speed += this.friction;
+            // Apply extra friction when moving backwards
+            this.speed += this.friction * 2;
             if (this.speed > 0) this.speed = 0;
         }
         


### PR DESCRIPTION
## Summary
- slow cats down faster when reversing

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876a6aa585483238335702da11e91b0